### PR TITLE
Continuous Delivery for the Chrome Extension

### DIFF
--- a/.github/workflows/data_host_extension.yml
+++ b/.github/workflows/data_host_extension.yml
@@ -1,0 +1,50 @@
+name: Data Host Chrome Extension Build
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - data_host/chrome_extension/**/*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: node:14.16.0
+    defaults:
+      run:
+        working-directory: data_host/chrome_extension
+
+    env:
+      FORCE_COLOR: true
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install node dependencies
+        run: yarn install
+
+      - name: Build staging data host chrome extension
+        run: yarn build
+
+      - name: Upload staging artifact zip file
+        uses: actions/upload-artifact@v2
+        with:
+          name: data-host-chrome-extension-staging
+          path: data_host/chrome_extension/build
+          if-no-files-found: error


### PR DESCRIPTION
Why:

* We want automatic builds of the Chrome extension.

This change addresses the need by:

* Automatically building the `data_host/chrome_extension/` project on
  each new PR and master branch commits