### PR TITLE
Add simple method to serialize object

### DIFF
--- a/support/sier-codec/src/object.rs
+++ b/support/sier-codec/src/object.rs
@@ -11,6 +11,15 @@ impl Object<'_> {
     pub fn schema(&self) -> &StructDef {
         self.schema
     }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        result.extend(self.schema.id().iter().cloned());
+        for value in &self.values {
+            result.extend(value.serialize());
+        }
+        result
+    }
 }
 
 impl<'s> Index<&'_ str> for Object<'s> {
@@ -89,6 +98,91 @@ impl Value {
         match self {
             Value::String(s) => Some(s),
             _ => None,
+        }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        match self {
+            Value::U8(v) => Vec::from(v.to_le_bytes()),
+            Value::U32(v) => Vec::from(v.to_le_bytes()),
+            Value::U64(v) => Vec::from(v.to_le_bytes()),
+            Value::String(v) => var_int(v.len()).into_iter().chain(v.bytes()).collect(),
+        }
+    }
+}
+
+fn var_int(val: usize) -> Vec<u8> {
+    // VarInts use 8 bits to encode 7 bits, so need to be multiplied by 8/7.
+    let capacity = core::mem::size_of::<usize>() * 8 / 7 + 1;
+    let mut result = Vec::with_capacity(capacity);
+
+    let mut remaining = val;
+    loop {
+        let mut byte: u8 = (remaining as u8) & 0b01111111;
+
+        remaining >>= 7;
+
+        if remaining > 0 {
+            byte |= 0b10000000;
+            result.push(byte);
+        } else {
+            result.push(byte);
+            break;
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(test)]
+    mod value_serialize {
+        use super::*;
+
+        #[test]
+        fn u8_is_byte() {
+            assert_eq!(Value::U8(42).serialize(), vec![42]);
+        }
+
+        #[test]
+        fn u32_is_le_bytes() {
+            assert_eq!(Value::U32(42).serialize(), vec![42, 0, 0, 0]);
+        }
+
+        #[test]
+        fn u64_is_le_bytes() {
+            assert_eq!(Value::U64(42).serialize(), vec![42, 0, 0, 0, 0, 0, 0, 0]);
+        }
+
+        #[test]
+        fn string_is_length_prefixed() {
+            assert_eq!(
+                Value::String(String::from("foo")).serialize(),
+                vec![3, 102, 111, 111]
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod var_int {
+        use super::*;
+
+        #[test]
+        fn zero_is_zero() {
+            assert_eq!(var_int(0), vec![0]);
+        }
+
+        #[test]
+        fn one_is_one() {
+            assert_eq!(var_int(1), vec![1]);
+        }
+
+        #[test]
+        fn two_bytes() {
+            assert_eq!(var_int(128), vec![128, 1]);
         }
     }
 }

--- a/support/sier-codec/tests/integrated.rs
+++ b/support/sier-codec/tests/integrated.rs
@@ -57,6 +57,30 @@ fn construct_numbers() {
     assert_eq!(message["bar"].as_u32(), Some(43));
 }
 
+#[test]
+fn serialize_object() {
+    let mut parser = Parser::default();
+    parser.add_file_defs(MULTIPLE_NUMBERS).unwrap();
+
+    let def = parser.struct_def("Foo").unwrap();
+    let message = def
+        .builder()
+        .set("foo", 42u64)
+        .set("bar", 43u32)
+        .try_build()
+        .unwrap();
+
+    let encoded = message.serialize();
+    let expected = def
+        .id()
+        .iter()
+        .chain(&[42, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0])
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert_eq!(encoded, expected);
+}
+
 const STRING: &'static str = r#"
 struct Foo {
     foo :string;


### PR DESCRIPTION
Next PR will add quickcheck testing that arbitrary objects can be serialized and deserialized with the resulting objects matching.