### PR TITLE
Give unclaimed minting rewards to a configured account

### DIFF
--- a/blockchain/pallets/minting/src/mock.rs
+++ b/blockchain/pallets/minting/src/mock.rs
@@ -73,6 +73,8 @@ parameter_types! {
     pub const MaxRewardPerUser: u64 = 42;
     pub const MaxMintPerPeriod: u64 = 200;
     pub const MintEveryNBlocks: u64 = 10;
+
+    pub const ExcessMintingReceiver: u64 = 1234;
 }
 
 impl fractal_minting::Config for Test {
@@ -81,6 +83,7 @@ impl fractal_minting::Config for Test {
     type MaxRewardPerUser = MaxRewardPerUser;
     type MaxMintPerPeriod = MaxMintPerPeriod;
     type MintEveryNBlocks = MintEveryNBlocks;
+    type ExcessMintingReceiver = ExcessMintingReceiver;
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/blockchain/pallets/minting/src/tests.rs
+++ b/blockchain/pallets/minting/src/tests.rs
@@ -147,6 +147,35 @@ mod register_identity {
     }
 
     #[test]
+    fn unclaimed_minting_goes_to_excess_receiver() {
+        new_test_ext().execute_with(|| {
+            run_to_next_minting();
+
+            assert_eq!(
+                Balances::free_balance(&<Test as crate::Config>::ExcessMintingReceiver::get()),
+                <Test as crate::Config>::MaxMintPerPeriod::get()
+            );
+        });
+    }
+
+    #[test]
+    fn only_unclaimed_minting_goes_to_excess_receiver() {
+        new_test_ext().execute_with(|| {
+            register_id_account(1, 1);
+            register_for_minting(1);
+
+            run_to_next_minting();
+
+            let expected = <Test as crate::Config>::MaxMintPerPeriod::get()
+                - <Test as crate::Config>::MaxRewardPerUser::get();
+            assert_eq!(
+                Balances::free_balance(&<Test as crate::Config>::ExcessMintingReceiver::get()),
+                expected
+            );
+        });
+    }
+
+    #[test]
     fn new_registration_clears_dataset() {
         new_test_ext().execute_with(|| {
             register_id_account(1, 1);

--- a/blockchain/runtime/Cargo.toml
+++ b/blockchain/runtime/Cargo.toml
@@ -16,7 +16,7 @@ substrate-wasm-builder={version = '4.0.0', git = 'https://github.com/paritytech/
 [dependencies]
 # external dependencies
 codec = {default-features = false, features = ['derive'], package = 'parity-scale-codec', version = '2.0.0'}
-hex-literal= {optional = true, version = '0.3.1'}
+hex-literal= {version = '0.3.1'}
 
 # Substrate dependencies
 frame-benchmarking = {default-features = false, optional = true, version = '3.1.0', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-05'}
@@ -54,7 +54,6 @@ runtime-benchmarks = [
 	'frame-support/runtime-benchmarks',
 	'frame-system-benchmarking',
 	'frame-system/runtime-benchmarks',
-	'hex-literal',
 	'pallet-balances/runtime-benchmarks',
 	'pallet-timestamp/runtime-benchmarks',
 	'sp-runtime/runtime-benchmarks',

--- a/blockchain/runtime/src/lib.rs
+++ b/blockchain/runtime/src/lib.rs
@@ -271,6 +271,9 @@ parameter_types! {
     pub const MaxRewardPerUser: Balance = 3 * UNIT_BALANCE;
     pub const MaxMintPerPeriod: Balance = 80_000 * UNIT_BALANCE;
     pub const MintEveryNBlocks: BlockNumber = DAYS;
+
+    // Charlie development account. Seed: "//Charlie"
+    pub const ExcessMintingReceiver: AccountId = AccountId::new(hex_literal::hex!["90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22"]);
 }
 
 impl fractal_minting::Config for Runtime {
@@ -281,6 +284,8 @@ impl fractal_minting::Config for Runtime {
     type MaxRewardPerUser = MaxRewardPerUser;
     type MaxMintPerPeriod = MaxMintPerPeriod;
     type MintEveryNBlocks = MintEveryNBlocks;
+
+    type ExcessMintingReceiver = ExcessMintingReceiver;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/blockchain/runtime/src/lib.rs
+++ b/blockchain/runtime/src/lib.rs
@@ -272,8 +272,8 @@ parameter_types! {
     pub const MaxMintPerPeriod: Balance = 80_000 * UNIT_BALANCE;
     pub const MintEveryNBlocks: BlockNumber = DAYS;
 
-    // Charlie development account. Seed: "//Charlie"
-    pub const ExcessMintingReceiver: AccountId = AccountId::new(hex_literal::hex!["90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22"]);
+    // 5F6Tgor2L4kyiS8PdWFucjMTRteufiqxSFxBzELn9kRA3wUy
+    pub const ExcessMintingReceiver: AccountId = AccountId::new(hex_literal::hex!["860b7d9d3e03cbd6a4fcec790f42260a64cb8673c318c4884046ca4c76cc3841"]);
 }
 
 impl fractal_minting::Config for Runtime {


### PR DESCRIPTION
While here:

- Reduce the number of storage accesses by aggregating Imbalances.
- Change the event emitted to include additional useful data.