### PR TITLE
Remove 'module' build from polkadot-utils

### DIFF
--- a/support/@trustfractal/polkadot-utils/package.json
+++ b/support/@trustfractal/polkadot-utils/package.json
@@ -4,14 +4,12 @@
   "description": "Utilities to make interacting with Substrate nodes robust and efficient.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
-  "module": "build/module/index.js",
   "repository": "https://github.com/shelbyd/@fractal/polkadot-utils",
   "license": "MIT",
   "keywords": [],
   "scripts": {
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.json",
-    "build:module": "tsc -p tsconfig.module.json",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:lint": "eslint src --ext .ts --fix",
@@ -68,7 +66,6 @@
   },
   "files": [
     "build/main",
-    "build/module",
     "!**/*.spec.*",
     "!**/*.json",
     "CHANGELOG.md",


### PR DESCRIPTION
This was causing problems in the wallet, and it's not necessary.