### PR TITLE
Improve indexing performance by ~2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,7 +1956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.3",
+ "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2128,6 +2128,7 @@ dependencies = [
  "ramhorns",
  "serde",
  "serde_json",
+ "shared_lru",
  "simple_logger",
  "structopt",
 ]
@@ -3713,7 +3714,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.8.3",
+ "rand 0.8.4",
  "smallvec 1.6.1",
  "socket2 0.4.0",
  "void",
@@ -4964,7 +4965,7 @@ dependencies = [
  "log",
  "memmap2",
  "parking_lot 0.11.1",
- "rand 0.8.3",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -5440,7 +5441,7 @@ dependencies = [
  "hmac 0.11.0",
  "md-5",
  "memchr",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha2 0.9.5",
  "stringprep",
 ]
@@ -5655,7 +5656,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand 0.8.3",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -5767,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7402,6 +7403,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_lru"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bba4240f0a494305a21b23bbebb9213d425764ecb0af309f5cdb36aaf5b3c38"
+dependencies = [
+ "owning_ref",
+ "rand 0.8.4",
+ "serde_json",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8474,7 +8486,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall 0.2.8",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -9166,7 +9178,7 @@ dependencies = [
  "ipnet",
  "lazy_static",
  "log",
- "rand 0.8.3",
+ "rand 0.8.4",
  "smallvec 1.6.1",
  "thiserror",
  "tinyvec",
@@ -9230,7 +9242,7 @@ dependencies = [
  "httparse",
  "input_buffer",
  "log",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha-1 0.9.6",
  "url 2.2.2",
  "utf-8",
@@ -10049,7 +10061,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.11.1",
- "rand 0.8.3",
+ "rand 0.8.4",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7404,9 +7404,9 @@ dependencies = [
 
 [[package]]
 name = "shared_lru"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bba4240f0a494305a21b23bbebb9213d425764ecb0af309f5cdb36aaf5b3c38"
+checksum = "6d378496961dfffba56778a5cd8919aefe7f20208876d6077e4618587aa351d7"
 dependencies = [
  "owning_ref",
  "rand 0.8.4",

--- a/explorer/Cargo.toml
+++ b/explorer/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.72"
 simple_logger = "1.15.0"
 structopt = "0.3.25"
-shared_lru = { version = "0.1.1", features = ["serde_json"] }
+shared_lru = { version = "0.1.2", features = ["serde_json"] }
 
 [[bin]]
 name = "fractal_explorer_web"

--- a/explorer/Cargo.toml
+++ b/explorer/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.72"
 simple_logger = "1.15.0"
 structopt = "0.3.25"
+shared_lru = { version = "0.1.1", features = ["serde_json"] }
 
 [[bin]]
 name = "fractal_explorer_web"

--- a/explorer/src/data/mod.rs
+++ b/explorer/src/data/mod.rs
@@ -1,4 +1,5 @@
 use serde::*;
+use shared_lru::MemorySize;
 
 #[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
 #[serde(deny_unknown_fields)]
@@ -6,6 +7,14 @@ pub struct Block {
     pub hash: String,
     pub parent: String,
     pub number: u64,
+}
+
+impl MemorySize for Block {
+    fn bytes(&self) -> usize {
+        MemorySize::bytes(&self.hash)
+            + MemorySize::bytes(&self.parent)
+            + MemorySize::bytes(&self.number)
+    }
 }
 
 #[derive(Deserialize, Clone, PartialEq, Eq, Debug)]
@@ -23,4 +32,18 @@ pub struct Extrinsic {
 
     pub args: serde_json::Value,
     pub error: Option<serde_json::Value>,
+}
+
+impl MemorySize for Extrinsic {
+    fn bytes(&self) -> usize {
+        MemorySize::bytes(&self.block)
+            + MemorySize::bytes(&self.index_in_block)
+            + MemorySize::bytes(&self.nonce)
+            + MemorySize::bytes(&self.signer)
+            + MemorySize::bytes(&self.section)
+            + MemorySize::bytes(&self.method)
+            + MemorySize::bytes(&self.success)
+            + MemorySize::bytes(&self.args)
+            + MemorySize::bytes(&self.error)
+    }
 }

--- a/explorer/src/indexing/mod.rs
+++ b/explorer/src/indexing/mod.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 pub mod identities;
 
+/// Implementors of this interface should assume that they may revisit previously visited
+/// blocks/extrinsics.
 pub trait Indexer: Send {
     /// Whenever this value changes, and the first time run, this indexer will be restarted from
     /// block 0 and `[version_upgrade]` will be called.

--- a/explorer/src/ingest.js
+++ b/explorer/src/ingest.js
@@ -113,6 +113,11 @@ class PostgresStorage {
       await storage.setKey('ingestion/version', 1);
     }
 
+    console.log('Cleaning block/extrinsic keys');
+    await postgres.query(`DELETE FROM key_values WHERE key ~ 'block/\\d+$'`);
+    await postgres.query(`DELETE FROM key_values WHERE key ~ 'block/\\d+/extrinsic/\\d+$'`);
+
+    console.log('Done with migrations');
     return storage;
   }
 

--- a/explorer/src/ingest.js
+++ b/explorer/src/ingest.js
@@ -74,7 +74,7 @@ class PostgresStorage {
       await postgres.query(`DROP TABLE IF EXISTS block_json`);
       await postgres.query(`DROP TABLE IF EXISTS extrinsic_json`);
 
-      console.log('Migrating block_json');
+      console.log('Creating block_json');
       await postgres.query(`
         CREATE TABLE IF NOT EXISTS
         block_json (
@@ -91,7 +91,7 @@ class PostgresStorage {
         WHERE key ~ 'block/\\d+$'
       `);
 
-      console.log('Migrating extrinsic_json');
+      console.log('Creating extrinsic_json');
       await postgres.query(`
         CREATE TABLE IF NOT EXISTS
         extrinsic_json (

--- a/explorer/src/ingested.rs
+++ b/explorer/src/ingested.rs
@@ -80,7 +80,9 @@ impl Ingested {
             )?;
 
             let mut largest_unseen_extrinsic = HashMap::<u64, u64>::new();
+            let mut extrinsic_count = 0;
             while let Some(extr_row) = extrinsics.next()? {
+                extrinsic_count += 1;
                 let extrinsic: Extrinsic = serde_json::from_str(extr_row.get(&"json"))?;
 
                 let block_number = extr_row.get::<_, i64>(&"block_number") as u64;
@@ -108,7 +110,8 @@ impl Ingested {
             }
 
             let seen_extrinsics_for_next_block = largest_unseen_extrinsic.keys().any(|&k| k > load_block);
-            if seen_extrinsics_for_next_block {
+            let fewer_extrinsics_than_limit = extrinsic_count < limit;
+            if seen_extrinsics_for_next_block || fewer_extrinsics_than_limit {
                 return Ok(result);
             }
 

--- a/explorer/src/ingested.rs
+++ b/explorer/src/ingested.rs
@@ -1,45 +1,130 @@
-use postgres::Client;
+use postgres::{fallible_iterator::FallibleIterator, types::ToSql, Client};
+use shared_lru::*;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
-pub fn latest(pg: &mut Client) -> anyhow::Result<Option<u64>> {
-    if let Some(v) = get_key("ingestion/fully_ingested", pg)? {
-        Ok(Some(v.parse()?))
-    } else {
-        Ok(None)
-    }
-}
+use crate::data::{Block, Extrinsic};
 
 fn get_key(key: impl AsRef<str>, pg: &mut Client) -> anyhow::Result<Option<String>> {
-    let row = match pg
-        .query(
+    Ok(pg
+        .query_opt(
             "SELECT value FROM key_values WHERE key = $1",
             &[&key.as_ref()],
         )?
-        .into_iter()
-        .next()
-    {
-        Some(row) => row,
-        None => return Ok(None),
-    };
-
-    Ok(Some(row.get::<_, &str>(&"value").to_string()))
+        .map(|row| row.get::<_, &str>(&"value").to_string()))
 }
 
-pub fn load_block(number: u64, pg: &mut Client) -> anyhow::Result<Option<crate::data::Block>> {
-    if let Some(value) = get_key(format!("block/{}", number), pg)? {
-        Ok(Some(serde_json::from_str(&value)?))
-    } else {
-        Ok(None)
+pub struct Ingested {
+    blocks: LruCache<u64, Block>,
+    extrinsics: LruCache<(u64, u64), Option<Extrinsic>>,
+    client: Mutex<Client>,
+}
+
+impl Ingested {
+    pub fn create(lru: &Arc<SharedLru>, client: Client) -> Ingested {
+        Ingested {
+            blocks: lru.make_cache(),
+            extrinsics: lru.make_cache(),
+            client: Mutex::new(client),
+        }
     }
-}
 
-pub fn load_extrinsic(
-    block: u64,
-    index: u64,
-    pg: &mut Client,
-) -> anyhow::Result<Option<crate::data::Extrinsic>> {
-    if let Some(value) = get_key(format!("block/{}/extrinsic/{}", block, index), pg)? {
-        Ok(Some(serde_json::from_str(&value)?))
-    } else {
-        Ok(None)
+    pub fn latest(&self, pg: &mut Client) -> anyhow::Result<Option<u64>> {
+        Ok(get_key("ingestion/fully_ingested", pg)?
+            .map(|v| v.parse())
+            .transpose()?)
+    }
+
+    pub fn load_block(&self, number: u64) -> anyhow::Result<Option<Block>> {
+        match self.blocks.get(&number) {
+            Some(block) => Ok(Some(block.clone())),
+            None => Ok(self.load(number)?.map(|(block, _extrinsics)| block)),
+        }
+    }
+
+    fn load(&self, load_block: u64) -> anyhow::Result<Option<(Block, HashMap<u64, Extrinsic>)>> {
+        let mut client = self.client.lock().unwrap();
+        let mut limit: i64 = 10_000;
+
+        loop {
+            // TODO(shelbyd): Could merge these queries to not waste time processing unnecessary
+            // blocks.
+            let mut blocks = client.query_raw(
+                "SELECT number, json FROM block_json WHERE number >= $1
+                ORDER BY number
+                LIMIT $2",
+                [&(load_block as i64), &limit],
+            )?;
+
+            let mut result: Option<(Block, HashMap<u64, Extrinsic>)> = None;
+
+            while let Some(block_row) = blocks.next()? {
+                let block: Block = serde_json::from_str(block_row.get(&"json"))?;
+                let number: i64 = block_row.get(&"number");
+
+                if (number as u64) == load_block {
+                    result = Some((block.clone(), HashMap::new()));
+                }
+
+                self.blocks.insert(number as u64, block);
+            }
+            drop(blocks);
+
+            let mut extrinsics = client.query_raw(
+                "SELECT block_number, index, json FROM extrinsic_json WHERE block_number >= $1
+                ORDER BY block_number, index
+                LIMIT $2",
+                [&(load_block as i64) as &dyn ToSql, &limit],
+            )?;
+
+            let mut largest_unseen_extrinsic = HashMap::<u64, u64>::new();
+            while let Some(extr_row) = extrinsics.next()? {
+                let extrinsic: Extrinsic = serde_json::from_str(extr_row.get(&"json"))?;
+
+                let block_number = extr_row.get::<_, i64>(&"block_number") as u64;
+                let index = extr_row.get::<_, i64>(&"index") as u64;
+
+                if block_number == load_block {
+                    result
+                        .as_mut()
+                        .expect("should have visited block")
+                        .1
+                        .insert(index, extrinsic.clone());
+                }
+
+                self.extrinsics
+                    .insert((block_number, index), Some(extrinsic));
+
+                let unseen = largest_unseen_extrinsic.entry(block_number).or_default();
+                *unseen = std::cmp::max(index + 1, *unseen);
+            }
+
+            for (block, unseen) in &largest_unseen_extrinsic {
+                if largest_unseen_extrinsic.contains_key(&(block + 1)) {
+                    self.extrinsics.insert((*block, *unseen), None);
+                }
+            }
+
+            let seen_extrinsics_for_next_block = largest_unseen_extrinsic.keys().any(|&k| k > load_block);
+            if seen_extrinsics_for_next_block {
+                return Ok(result);
+            }
+
+            // There may be more extrinsics to return. Double the limit and try again.
+            // This is unlikely to be hit.
+            limit *= 2;
+            log::info!("Did not load enough extrinsics, now loading {}", limit);
+        }
+    }
+
+    pub fn load_extrinsic(&self, block: u64, index: u64) -> anyhow::Result<Option<Extrinsic>> {
+        if let Some(extr) = self.extrinsics.get(&(block, index)) {
+            return Ok(extr.clone());
+        }
+        Ok(self
+            .load(block)?
+            .and_then(|(_block, mut extrs)| extrs.remove(&index)))
     }
 }

--- a/explorer/src/ingested.rs
+++ b/explorer/src/ingested.rs
@@ -109,7 +109,8 @@ impl Ingested {
                 }
             }
 
-            let seen_extrinsics_for_next_block = largest_unseen_extrinsic.keys().any(|&k| k > load_block);
+            let seen_extrinsics_for_next_block =
+                largest_unseen_extrinsic.keys().any(|&k| k > load_block);
             let fewer_extrinsics_than_limit = extrinsic_count < limit;
             if seen_extrinsics_for_next_block || fewer_extrinsics_than_limit {
                 return Ok(result);


### PR DESCRIPTION
Also store block and extrinsic JSON in dedicated tables. Keeping them in a simple key/value store makes it difficult to extract relevant sections of keys since they are lexicographically ordered.