### PR TITLE
Remove 'purposes' from token_distribution pallet

### DIFF
--- a/blockchain/pallets/data_capture/src/mock.rs
+++ b/blockchain/pallets/data_capture/src/mock.rs
@@ -77,15 +77,16 @@ parameter_types! {
     pub const IssuanceHalfLife: u64 = 600;
     pub const IssuanceCompleteAt: u64 = 10_000;
     pub const MaxRewardPerUser: u64 = 420_000;
+    pub const HoldingAccount: u64 = 42;
 }
 
 impl fractal_data_capture::Config for Test {
     type Event = Event;
 
     type MintEveryNBlocks = MintEveryNBlocks;
-
     type MaxRewardPerUser = MaxRewardPerUser;
-    type TokenDistribution = FractalTokenDistribution;
+
+    type HoldingAccount = HoldingAccount;
 }
 
 impl fractal_token_distribution::Config for Test {

--- a/blockchain/runtime/src/lib.rs
+++ b/blockchain/runtime/src/lib.rs
@@ -281,6 +281,10 @@ parameter_types! {
     pub const TotalIssuance: Balance = 400_000_000 * UNIT_BALANCE;
     pub const IssuanceHalfLife: BlockNumber = 10 * YEARS;
     pub const IssuanceCompleteAt: BlockNumber = 120 * YEARS;
+
+    // 5FCLDataCaptureRewardsxxxxxxxxxxxxxxxxxxxxxxxk7C
+    pub const DataCaptureHoldingAccount: AccountId =
+        AccountId::new(hex_literal::hex!("8a85d1a80e8d35f0c904d78df91ac99f03d623ccf349ad1dce71a3011fdde447"));
 }
 
 impl fractal_data_capture::Config for Runtime {
@@ -289,7 +293,7 @@ impl fractal_data_capture::Config for Runtime {
     type MaxRewardPerUser = MaxRewardPerUser;
     type MintEveryNBlocks = MintEveryNBlocks;
 
-    type TokenDistribution = FractalTokenDistribution;
+    type HoldingAccount = DataCaptureHoldingAccount;
 }
 
 impl fractal_token_distribution::Config for Runtime {


### PR DESCRIPTION
This is better served by sending to a clearly inaccessible address and using the on-chain code to update the address's balance.