### PR TITLE
Fix CircleCI to actually build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - *cargo_fetch_retry
       - run:
           name: Build all targets
-          command: cargo build --release --verbose
+          command: cargo build --release --jobs 1
       - *save_cache
       - run:
           name: Run all tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - run:
           name: Build all targets
           command: cargo build --release --jobs 1
+          no_output_timeout: 30m
       - *save_cache
       - run:
           name: Run all tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,10 @@ jobs:
       - *setup_rust
       - *version_info
       - checkout
-      - *restore_cache
       - *cargo_fetch_retry
       - run:
           name: Build all targets
-          command: cargo build --release --verbose --jobs 1
+          command: cargo build --release --verbose
       - *save_cache
       - run:
           name: Run all tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,7 @@ setup_steps:
   - &save_cache
     save_cache:
       paths:
-        - /usr/local/cargo/registry
-        - target/release/.fingerprint
-        - target/release/build
-        - target/release/deps
+        - target/
       key: v1-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}-{{ .Environment.CACHE_VERSION }}
 
 jobs:
@@ -53,6 +50,7 @@ jobs:
       - *setup_rust
       - *version_info
       - checkout
+      - *restore_cache
       - *cargo_fetch_retry
       - run:
           name: Build all targets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,7 @@ jobs:
       - *cargo_fetch_retry
       - run:
           name: Build all targets
-          command: cargo build --release
-          no_output_timeout: 30m
+          command: cargo build --release --verbose --jobs 1
       - *save_cache
       - run:
           name: Run all tests


### PR DESCRIPTION
Apparently we can't run with multiple jobs. It shouldn't interfere too much if we cache the incremental compilation/crate compilation results. Perhaps it would work with >1 jobs, but for now, just keep it to 1.