### PR TITLE
Acala deployment: gas params

### DIFF
--- a/explorer/evm/package.json
+++ b/explorer/evm/package.json
@@ -4,6 +4,7 @@
     "@nomicfoundation/hardhat-toolbox": "^2.0.0"
   },
   "devDependencies": {
+    "@acala-network/eth-providers": "^2.4.21",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/providers": "^5.7.1",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.3",

--- a/explorer/evm/scripts/deploy_karura.js
+++ b/explorer/evm/scripts/deploy_karura.js
@@ -1,0 +1,30 @@
+const { ethers } = require('hardhat');
+const { txParams } = require("../utils/karuraAndAcalaTransactionHelpers");
+
+async function main() {
+  const gasParams = await txParams();
+  
+  const FCLToken = await ethers.getContractFactory("FCLToken");
+  const tokenInstance = await FCLToken.deploy(gasParams);
+  await tokenInstance.deployed();
+
+  const minterRole = await tokenInstance.MINTER_ROLE();
+  const minter = new ethers.Wallet("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+  await tokenInstance.grantRole(minterRole, minter.address, gasParams);
+
+  const FCLBurner = await ethers.getContractFactory("FCLBurner");
+  const burnerInstance = await FCLBurner.deploy(tokenInstance.address, gasParams);
+  await burnerInstance.deployed();
+
+  console.log(JSON.stringify({
+    tokenContract: tokenInstance.address,
+    minterAddress: minter.address,
+    minterKey: minter.privateKey,
+    burnerContract: burnerInstance.address,
+  }, null, 2));
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/explorer/evm/utils/karuraAndAcalaTransactionHelpers.js
+++ b/explorer/evm/utils/karuraAndAcalaTransactionHelpers.js
@@ -1,0 +1,22 @@
+const { calcEthereumTransactionParams } = require("@acala-network/eth-providers");
+
+async function txParams() {
+    const txFeePerGas = '199999946752';
+    const storageByteDeposit = '100000000000000';
+    const blockNumber = await ethers.provider.getBlockNumber();
+
+    const ethParams = calcEthereumTransactionParams({
+      gasLimit: '31000000',
+      validUntil: (blockNumber + 100).toString(),
+      storageLimit: '64001',
+      txFeePerGas,
+      storageByteDeposit
+    });
+
+    return {
+        gasPrice: ethParams.txGasPrice,
+        gasLimit: ethParams.txGasLimit
+    };
+}
+
+module.exports = { txParams };


### PR DESCRIPTION
Adds:
 * `./utils/karuraAndAcalaTransactionHelpers.js` for Acala/Karura gas parameter estimation, as per [these docs](https://evmdocs.acala.network/tutorials/hardhat-tutorials/helloworld-tutorial#transaction-helper-utility)
 * `./scripts/deploy_karura.js` for deployment, which uses the aforementioned helper for `overrides` in [`contractFactory.deploy`](https://docs.ethers.io/v5/api/contract/contract-factory/#ContractFactory-deploy) and [`contract.METHOD_NAME`](https://docs.ethers.io/v5/api/contract/contract/#contract-functionsSend).

Tested using Karura's public RPC as per [these docs](https://evmdocs.acala.network/network/network-configuration#karura-main-network) in `hardhat.config.js`:

```
diff --git a/explorer/evm/hardhat.config.js b/explorer/evm/hardhat.config.js
index e76a7ec..feb0f3e 100644
--- a/explorer/evm/hardhat.config.js
+++ b/explorer/evm/hardhat.config.js
@@ -10,5 +10,9 @@ module.exports = {
         interval: [3000, 6000],
       },
     },
+    karura: {
+      url: "https://rpc.evm.karura.network",
+      accounts: [process.env.KARURA_DEPLOYER_PRIVATE_KEY],
+    },
   },
 };
```